### PR TITLE
Fix issue #17, observe all text editors

### DIFF
--- a/lib/file-types.coffee
+++ b/lib/file-types.coffee
@@ -22,7 +22,7 @@ module.exports =
       for editor in atom.workspace.getTextEditors()
         @_tryToSetGrammar editor
 
-    @_off.push atom.workspace.getTextEditors().forEach (editor) =>
+    @_off.push atom.workspace.observeTextEditors (editor) =>
       # TODO: Does this cause a memory leak?
       @_off.push editor.onDidChangePath =>
         @_tryToSetGrammar editor


### PR DESCRIPTION
Hello,

Looks like this change of one line will fix #17.

Needs to observe text editors so we get notified when editors are added. But I don't understand why `atom-file-types` has ever worked before, so maybe I've misunderstood something...