### PR TITLE
Update available grammars listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An extension matcher will be converted into a RegExp matcher. The example above 
 To see all available grammars registered in your Atom instance, open the Developer Tools Console and execute the following:
 
 ```javascript
-console.log(Object.keys(atom.grammars.grammarsByScopeName).sort().join("\n"))
+console.log(Object.keys(atom.grammars.textmateRegistry.grammarsByScopeName).sort().join("\n"))
 ```
 
 ## RegExp Matchers


### PR DESCRIPTION
Available grammars listing command seems to be outdated. Fix #64 